### PR TITLE
Add support for serialized data (strings) in datasets.putItems()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+xxxxxxxxxxxxxxxxxxx
+===================
+- Added support for pre-serialized data (strings) to `Apify.datasets.putItems()`.  
+
 0.2.10 / 2018-05-23
 ===================
 - Added `executionId` parameter to getCrawlerSettings method. You can get crawler settings for specific execution with that.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-client",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Apify API client for JavaScript",
   "main": "build/index.js",
   "keywords": [

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -312,7 +312,8 @@ export default {
      * @instance
      * @param {Object} options
      * @param {String} options.datasetId - Unique dataset ID
-     * @param {Object | Array} options.data - Object or Array of objects, only objects that can be JSON.stringified are allowed
+     * @param {Object | Array | String} options.data - String, Object or Array of objects,
+     *                                                 only objects that can be JSON.stringified are allowed.
      * @param {String} [options.token] - Your API token at apify.com. This parameter is required
      *                                   only when using "username~dataset-name" format for datasetId.
      * @param callback
@@ -322,13 +323,15 @@ export default {
         const { baseUrl, datasetId, data, token } = options;
         checkParamOrThrow(baseUrl, 'baseUrl', 'String');
         checkParamOrThrow(datasetId, 'datasetId', 'String');
-        checkParamOrThrow(data, 'data', 'Object | Array');
+        checkParamOrThrow(data, 'data', 'Object | Array | String');
         checkParamOrThrow(token, 'token', 'Maybe String');
 
         const query = {};
         if (token) query.token = token;
 
-        return gzipPromise(options.promise, JSON.stringify(data))
+        const payload = typeof data === 'string' ? data : JSON.stringify(data);
+
+        return gzipPromise(options.promise, payload)
             .then((gzipedBody) => {
                 const requestOpts = {
                     url: `${baseUrl}${BASE_PATH}/${datasetId}/items`,

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -312,8 +312,8 @@ export default {
      * @instance
      * @param {Object} options
      * @param {String} options.datasetId - Unique dataset ID
-     * @param {Object | Array | String} options.data - String, Object or Array of objects,
-     *                                                 only objects that can be JSON.stringified are allowed.
+     * @param {Object | Array | String} options.data - Object, Array of objects or a String. String must be a valid JSON.
+     *                                                 Arrays and Objects must be JSON.stringifiable.
      * @param {String} [options.token] - Your API token at apify.com. This parameter is required
      *                                   only when using "username~dataset-name" format for datasetId.
      * @param callback

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -381,5 +381,28 @@ describe('Dataset', () => {
                 .datasets
                 .putItems({ datasetId, data });
         });
+        it('putItems() works with string', () => {
+            const datasetId = 'some-id';
+            const contentType = 'application/json; charset=utf-8';
+            const data = JSON.stringify([{ someData: 'someValue' }, { someData: 'someValue' }]);
+
+            requestExpectCall({
+                body: gzipSync(data),
+                headers: {
+                    'Content-Type': contentType,
+                    'Content-Encoding': 'gzip',
+                },
+                json: false,
+                method: 'POST',
+                url: `${BASE_URL}${BASE_PATH}/${datasetId}/items`,
+                qs: {},
+            });
+
+            const apifyClient = new ApifyClient(OPTIONS);
+
+            return apifyClient
+                .datasets
+                .putItems({ datasetId, data });
+        });
     });
 });


### PR DESCRIPTION
Allows strings as data to `putItems()` to support large payload chunking.

See: https://github.com/apifytech/apify-js/pull/138