### PR TITLE
Add support for parsing HTML and XML

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,9 @@ const RATE_LIMIT_EXCEEDED_STATUS_CODE = 429;
 const EXP_BACKOFF_MILLIS = 500;
 const EXP_BACKOFF_MAX_REPEATS = 8; // 64s
 const CONTENT_TYPE_JSON = 'application/json';
+const CONTENT_TYPE_XML = 'application/xml';
 const CONTENT_TYPE_TEXT_PLAIN = 'text/plain';
+const CONTENT_TYPE_TEXT_HTML = 'text/html';
 const CLIENT_USER_AGENT = `ApifyClient/${version} (${os.type()}; Node/${process.version})`;
 const PARSE_DATE_FIELDS_MAX_DEPTH = 3; // obj.data.someArrayField.[x].field
 const PARSE_DATE_FIELDS_KEY_SUFFIX = 'At';
@@ -209,6 +211,8 @@ export const parseBody = (body, contentType) => {
 
     switch (type) {
         case CONTENT_TYPE_JSON: return JSON.parse(body);
+        case CONTENT_TYPE_XML:
+        case CONTENT_TYPE_TEXT_HTML:
         case CONTENT_TYPE_TEXT_PLAIN: return body.toString();
         default: return body;
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -536,6 +536,14 @@ describe('utils.parseBody()', () => {
         expect(parseBody(inputBuffer, 'text/plain; charset=something')).to.be.eql(inputStr);
         expect(parseBody(inputBuffer, 'text/plain; charset=utf-8')).to.be.eql(inputStr);
         expect(parseBody(inputBuffer, 'text/something')).to.be.eql(inputBuffer);
+
+        expect(parseBody(inputBuffer, 'text/html')).to.be.eql(inputStr);
+        expect(parseBody(inputBuffer, 'text/html; charset=something')).to.be.eql(inputStr);
+        expect(parseBody(inputBuffer, 'text/html; charset=utf-8')).to.be.eql(inputStr);
+
+        expect(parseBody(inputBuffer, 'application/xml')).to.be.eql(inputStr);
+        expect(parseBody(inputBuffer, 'application/xml; charset=something')).to.be.eql(inputStr);
+        expect(parseBody(inputBuffer, 'application/xml; charset=utf-8')).to.be.eql(inputStr);
     });
 });
 


### PR DESCRIPTION
Adds HTML and XML to `parseBody()`
to fix: https://github.com/apifytech/apify-js/issues/130
and support: https://github.com/apifytech/apify-js/pull/140