### PR TITLE
Bug fix: Dataset Exponential Backoff

### DIFF
--- a/src/datasets.js
+++ b/src/datasets.js
@@ -327,19 +327,21 @@ export default {
             try {
                 if (!disableBodyParser) wrappedItems.items = parseBody(wrappedItems.items, contentType);
             } catch (e) {
-                throw new RetryableError(e);
+                if (e.message === 'Unexpected end of JSON input') {
+                    throw new RetryableError(e);
+                }
+                throw e;
             }
             return wrappedItems;
         };
 
         const getData = async () => {
-            let response;
             try {
-                response = await requestPromise(requestOpts);
-            } catch (e) {
-                catchNotFoundOrThrow(e);
+                const response = await requestPromise(requestOpts);
+                return parseResponse(response);
+            } catch (err) {
+                catchNotFoundOrThrow(err);
             }
-            return parseResponse(response);
         };
 
         return retryWithExpBackoff({ func: getData, expBackoffMillis: 200, expBackoffMaxRepeats: 5 });

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -327,7 +327,7 @@ export default {
             try {
                 if (!disableBodyParser) wrappedItems.items = parseBody(wrappedItems.items, contentType);
             } catch (e) {
-                if (e.message === 'Unexpected end of JSON input') {
+                if (e.message.includes('Unexpected end of JSON input')) {
                     throw new RetryableError(e);
                 }
                 throw e;

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -5,7 +5,7 @@ import * as exponentialBackoff from 'apify-shared/exponential_backoff';
 import ApifyClient from '../build';
 import { mockRequest, requestExpectCall, requestExpectErrorCall, restoreRequest } from './_helper';
 import * as utils from '../build/utils';
-import { getData, parseResponse, BASE_PATH } from '../build/datasets';
+import { getDatasetItems, parseDatasetItemsResponse, BASE_PATH } from '../build/datasets';
 import ApifyClientError, { NOT_FOUND_STATUS_CODE } from '../src/apify_error';
 
 const BASE_URL = 'http://example.com/something';
@@ -227,18 +227,18 @@ describe('Dataset', () => {
                 .then(given => expect(given).to.be.eql(expected));
         });
 
-        describe('getData()', () => {
+        describe('getDatasetItems()', () => {
             const message = 'CUSTOM ERROR';
-            it('getData() should return null for 404', async () => {
+            it('getDatasetItems() should return null for 404', async () => {
                 const requestPromise = () => {
                     throw new ApifyClientError('NOTFOUND', 'Not found', { statusCode: NOT_FOUND_STATUS_CODE });
                 };
 
-                const data = await getData(requestPromise);
+                const data = await getDatasetItems(requestPromise);
                 expect(data).to.eql(null);
             });
 
-            it('parseResponse() should rethrow errors', async () => {
+            it('parseDatasetItemsResponse() should rethrow errors', async () => {
                 const response = {
                     headers: {
                         'content-type': 'application/json',
@@ -253,7 +253,7 @@ describe('Dataset', () => {
                 });
                 let error;
                 try {
-                    parseResponse(response, false);
+                    parseDatasetItemsResponse(response, false);
                 } catch (e) {
                     error = e;
                 }
@@ -262,7 +262,7 @@ describe('Dataset', () => {
                 utils.parseBody.restore();
             });
 
-            it('parseResponse() should throw RetryableError if  Unexpected end of JSON input', async () => {
+            it('parseDatasetItemsResponse() should throw RetryableError if  Unexpected end of JSON input', async () => {
                 const response = {
                     headers: {
                         'content-type': 'application/json',
@@ -277,7 +277,7 @@ describe('Dataset', () => {
                 });
                 let error;
                 try {
-                    parseResponse(response, false);
+                    parseDatasetItemsResponse(response, false);
                 } catch (e) {
                     error = e;
                 }

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -273,7 +273,7 @@ describe('Dataset', () => {
                 };
                 const stub = sinon.stub(utils, 'parseBody');
                 stub.callsFake(() => {
-                    throw new Error('Unexpected end of JSON input');
+                    JSON.parse('{"foo":');
                 });
                 let error;
                 try {

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -1,8 +1,13 @@
 import { expect } from 'chai';
 import { gzipSync } from 'zlib';
+import sinon from 'sinon';
+import * as exponentialBackoff from 'apify-shared/exponential_backoff';
+import { retryWithExpBackoff } from 'apify-shared/exponential_backoff';
 import ApifyClient from '../build';
-import { BASE_PATH } from '../build/datasets';
 import { mockRequest, requestExpectCall, requestExpectErrorCall, restoreRequest } from './_helper';
+import * as utils from '../build/utils';
+import { getData, parseResponse, BASE_PATH } from '../build/datasets';
+import ApifyClientError, { NOT_FOUND_STATUS_CODE } from '../src/apify_error';
 
 const BASE_URL = 'http://example.com/something';
 const OPTIONS = { baseUrl: BASE_URL };
@@ -221,6 +226,87 @@ describe('Dataset', () => {
                 .datasets
                 .getItems({ datasetId })
                 .then(given => expect(given).to.be.eql(expected));
+        });
+
+        describe('getData()', () => {
+            const message = 'CUSTOM ERROR';
+            it('getData() should return null for 404', async () => {
+                const requestPromise = () => {
+                    throw new ApifyClientError('NOTFOUND', 'Not found', { statusCode: NOT_FOUND_STATUS_CODE });
+                };
+
+                const data = await getData(requestPromise);
+                expect(data).to.eql(null);
+            });
+
+            it('parseResponse() should rethrow errors', async () => {
+                const response = {
+                    headers: {
+                        'content-type': 'application/json',
+                    },
+                    body: {
+
+                    },
+                };
+                const stub = sinon.stub(utils, 'parseBody');
+                stub.callsFake(() => {
+                    throw new Error(message);
+                });
+                let error;
+                try {
+                    parseResponse(response, false);
+                } catch (e) {
+                    error = e;
+                }
+                expect(error instanceof Error).to.be.eql(true);
+                expect(error.message).to.be.eql(message);
+                utils.parseBody.restore();
+            });
+
+            it('parseResponse() should throw RetryableError if  Unexpected end of JSON input', async () => {
+                const response = {
+                    headers: {
+                        'content-type': 'application/json',
+                    },
+                    body: {
+
+                    },
+                };
+                const stub = sinon.stub(utils, 'parseBody');
+                stub.callsFake(() => {
+                    throw new Error('Unexpected end of JSON input');
+                });
+                let error;
+                try {
+                    parseResponse(response, false);
+                } catch (e) {
+                    error = e;
+                }
+                expect(error instanceof exponentialBackoff.RetryableError).to.be.eql(true);
+                expect(error.error.message).to.be.eql('Unexpected end of JSON input');
+                utils.parseBody.restore();
+            });
+        });
+
+        it('getItems should retry with exponentialBackoff', async () => {
+            const datasetId = 'some-id';
+            let run = false;
+            const stub = sinon.stub(utils, 'parseBody');
+            const stubRetryWithExpBackoff = sinon.stub(exponentialBackoff, 'retryWithExpBackoff');
+            stub.callsFake(() => {
+                throw new exponentialBackoff.RetryableError(new Error(message));
+            });
+            stubRetryWithExpBackoff.callsFake(() => {
+                run = true;
+            });
+            try {
+                const apifyClient = new ApifyClient(OPTIONS);
+                await apifyClient.datasets.getItems({ datasetId, limit: 1, offset: 1 });
+            } catch (e) {
+            }
+            expect(run).to.be.eql(true);
+            utils.parseBody.restore();
+            exponentialBackoff.retryWithExpBackoff.restore();
         });
 
         it('getItems() limit and offset work', () => {

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { gzipSync } from 'zlib';
 import sinon from 'sinon';
 import * as exponentialBackoff from 'apify-shared/exponential_backoff';
-import { retryWithExpBackoff } from 'apify-shared/exponential_backoff';
 import ApifyClient from '../build';
 import { mockRequest, requestExpectCall, requestExpectErrorCall, restoreRequest } from './_helper';
 import * as utils from '../build/utils';
@@ -299,11 +298,8 @@ describe('Dataset', () => {
             stubRetryWithExpBackoff.callsFake(() => {
                 run = true;
             });
-            try {
-                const apifyClient = new ApifyClient(OPTIONS);
-                await apifyClient.datasets.getItems({ datasetId, limit: 1, offset: 1 });
-            } catch (e) {
-            }
+            const apifyClient = new ApifyClient(OPTIONS);
+            await apifyClient.datasets.getItems({ datasetId, limit: 1, offset: 1 });
             expect(run).to.be.eql(true);
             utils.parseBody.restore();
             exponentialBackoff.retryWithExpBackoff.restore();


### PR DESCRIPTION
I should probably add some tests that it really retries those errors. Is there a way how to stub the requestPromise function?  