### PR TITLE
Track rate limit errors per number of retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-0.5.8 / 2019/03/15
+xxx
+==================
+- `apifyClient.stats.rateLimitErrors` is now an `Array` and tracks errors per retry count. 
+
+0.5.9 / 2019/03/15
 ==================
 - Added `client.tasks.listWebhooks()` to list task webhooks.
 

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "lint": "npm run build && eslint src test"
   },
   "dependencies": {
-    "apify-shared": "^0.1.9",
-    "content-type": "^1.0.3",
-    "request": "^2.81.0",
-    "request-promise-native": "^1.0.5",
+    "apify-shared": "^0.1.32",
+    "content-type": "^1.0.4",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.7",
     "type-check": "^0.3.2",
-    "underscore": "^1.9.0"
+    "underscore": "^1.9.1"
   },
   "devDependencies": {
     "apify-jsdoc-template": "github:apifytech/apify-jsdoc-template",

--- a/src/index.js
+++ b/src/index.js
@@ -160,8 +160,8 @@ const ApifyClient = function (options = {}) {
         // Number of Apify API requests
         requests: 0,
 
-        // Number of times the API returned 429 error
-        rateLimitErrors: 0,
+        // Number of times the API returned 429 error. Spread based on number of retries.
+        rateLimitErrors: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 
         // TODO: We can add internalServerErrors and other stuff here...
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,7 +118,11 @@ export const requestPromise = async (options, stats) => {
             error = err;
         }
 
-        if (statusCode === RATE_LIMIT_EXCEEDED_STATUS_CODE && stats) stats.rateLimitErrors++;
+        if (statusCode === RATE_LIMIT_EXCEEDED_STATUS_CODE && stats) {
+            // Make sure this doesn't fail when someone increases number of retries on anything.
+            if (typeof stats.rateLimitErrors[iteration] === 'number') stats.rateLimitErrors[iteration - 1]++;
+            else stats.rateLimitErrors[iteration] = 1;
+        }
 
         // For status codes 300-499 except RATE_LIMIT_EXCEEDED_STATUS_CODE we immediately rejects the promise
         // since it's probably caused by invalid url (redirect 3xx) or invalid user input (4xx).

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -13,7 +13,7 @@ export const newEmptyStats = () => {
     return {
         calls: 0,
         requests: 0,
-        rateLimitErrors: 0,
+        rateLimitErrors: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     };
 };
 


### PR DESCRIPTION
Rate limit errors (429) are now tracked per retry:

```
[
    9, <- 9x on initial request
    3, <- 3x on first retry
    1, <- 1x on second retry
    0, <- no 429s on third retry
    ...etc
]
```